### PR TITLE
fix header, charset=utf-8

### DIFF
--- a/lib/FISPagelet.class.php
+++ b/lib/FISPagelet.class.php
@@ -585,7 +585,7 @@ class FISPagelet {
               
                 break;
             case self::MODE_QUICKLING:
-                header('Content-Type: text/json;charset: utf-8');
+                header('Content-Type: text/json; charset=utf-8');
                 if ($res['script']) {
                     $res['script'] = convertToUtf8(implode("\n", $res['script']));
                 }


### PR DESCRIPTION
fix MODE_QUICKLING header('Content-Type: text/json; charset=utf-8');
the previous "charset: utf-8" is wrong, may cause some bugs in IE9.
