### PR TITLE
resource_map.script 和 resource_map.style

### DIFF
--- a/lib/FISPagelet.class.php
+++ b/lib/FISPagelet.class.php
@@ -622,10 +622,10 @@ class FISPagelet {
                 $html .= '</script>';
                 $html .= "\n";
 
-                if ($res['script']) {
+                if (is_array($res['script'])) {
                     $res['script'] = convertToUtf8(implode("\n", $res['script']));
                 }
-                if ($res['style']) {
+                if (is_array($res['style'])) {
                     $res['style'] = convertToUtf8(implode("\n", $res['style']));
                 }
                 $html .= "\n";


### PR DESCRIPTION
resource_map.script和 resource_map.style有内容时是字符串（代码），没内容时目前是空数组，正常应该是空字符，代码中
```
//当$res['script']为空数组时这里为假，而默认是空数组
if ($res['script']) {
xxx
}
```
应该改成
```
if (is_array($res['script'])) {
xxx
}
```